### PR TITLE
Add Go Report Card badge. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Code Review Bot
 
-[![Build Status][travis-shield]][travis-link]
+[![Build Status][travis-badge]][travis-url]
+[![Go Report Card][go-report-card-badge]][go-report-card-url]
 
-[travis-shield]: https://travis-ci.org/google/code-review-bot.svg?branch=master
-[travis-link]: https://travis-ci.org/google/code-review-bot
+[travis-badge]: https://travis-ci.org/google/code-review-bot.svg?branch=master
+[travis-url]: https://travis-ci.org/google/code-review-bot
+[go-report-card-badge]: https://goreportcard.com/badge/github.com/google/code-review-bot
+[go-report-card-url]: https://goreportcard.com/report/github.com/google/code-review-bot
 
 ## Prerequisites
 


### PR DESCRIPTION
We now see full visibility into the existing issues and how to fix them.
Having a direct link makes it easier for visitors and committers to find
and fix the issues as well.

Fixes issue #4.