### PR TITLE
Add comments to exported types and methods.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,30 +25,41 @@ import (
 	"github.com/google/code-review-bot/logging"
 )
 
+// Config is the configuration for the `crbot` tool to specify the
+// authentication it should use and the scope at which it should run, whether
+// for all repos in a single organization, or a single specific repo.
 type Config struct {
 	Auth string `json:"auth" yaml:"auth"`
 	Org  string `json:"org,omitempty" yaml:"org,omitempty"`
 	Repo string `json:"repo,omitempty" yaml:"repo,omitempty"`
 }
 
+// Account represents a single user record, whether human or a bot, with a name,
+// email, and GitHub login.
 type Account struct {
 	Name  string `json:"name" yaml:"name"`
 	Email string `json:"email" yaml:"email"`
 	Login string `json:"github" yaml:"github"`
 }
 
+// Company represents a company record with a name, (optional) domain name(s),
+// and user accounts.
 type Company struct {
 	Name    string    `json:"name" yaml:"name"`
 	Domains []string  `json:"domains,omitempty" yaml:"domains,omitempty"`
 	People  []Account `json:"people" yaml:"people"`
 }
 
+// ClaSigners provides the overall structure of the CLA config: individual CLA
+// signers, bots, and corporate CLA signers.
 type ClaSigners struct {
 	People    []Account `json:"people,omitempty" yaml:"people,omitempty"`
 	Bots      []Account `json:"bots,omitempty" yaml:"bots,omitempty"`
 	Companies []Company `json:"companies,omitempty" yaml:"companies,omitempty"`
 }
 
+// ParseConfig parses the config from a YAML or JSON file and returns a `Config`
+// object.
 func ParseConfig(filename string) Config {
 	fileContents, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -71,6 +82,8 @@ func ParseConfig(filename string) Config {
 	return config
 }
 
+// ParseClaSigners parses the CLA signers config from a YAML or JSON file and
+// returns a `ClaSigners` object.
 func ParseClaSigners(filename string) ClaSigners {
 	fileContents, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/ghutil/ghutil.go
+++ b/ghutil/ghutil.go
@@ -25,6 +25,8 @@ import (
 	"github.com/google/code-review-bot/logging"
 )
 
+// The `[cla: yes]` and `[cla: no]` labels we expect to be predefined on a
+// given repository.
 const (
 	LabelClaYes = "cla: yes"
 	LabelClaNo  = "cla: no"
@@ -66,6 +68,9 @@ type GitHubClient struct {
 	PullRequests  PullRequestsService
 }
 
+// GitHubProcessSpec is the specification of the work to be done: for a single
+// organization and repo, the set of pull requests that need to be processed and
+// whether or not this tool should mutate the repo state.
 type GitHubProcessSpec struct {
 	Org        string
 	Repo       string

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -20,26 +20,32 @@ import (
 	"os"
 )
 
+// Errorf outputs an error log line with a formatting string.
 func Errorf(format string, a ...interface{}) (int, error) {
 	return fmt.Fprintf(os.Stderr, format+"\n", a...)
 }
 
+// Error outputs an error log line without a formatting string.
 func Error(a ...interface{}) (int, error) {
 	return fmt.Fprintln(os.Stderr, a...)
 }
 
-func Info(a ...interface{}) (int, error) {
-	return fmt.Println(a...)
-}
-
+// Infof outputs an info log line with a formatting string.
 func Infof(format string, a ...interface{}) (int, error) {
 	return fmt.Printf(format+"\n", a...)
 }
 
-func Fatal(a ...interface{}) {
-	log.Fatal(a...)
+// Info outputs an info log line without a formatting string.
+func Info(a ...interface{}) (int, error) {
+	return fmt.Println(a...)
 }
 
+// Fatalf outputs a fatal log line with a formatting string.
 func Fatalf(format string, a ...interface{}) {
 	log.Fatalf(format+"\n", a...)
+}
+
+// Fatal outputs a fatal log line without a formatting string.
+func Fatal(a ...interface{}) {
+	log.Fatal(a...)
 }


### PR DESCRIPTION
As noted in the Go Report Card:
https://goreportcard.com/report/github.com/google/code-review-bot
exported methods should have comments to explain what they do.

Note: the current state ("before") is that we're scoring 50% on the `golint` section of the report; I'm hoping the "after" state is that we'll score 100% on this metric.

@DiSiqueira — care to take a quick look at my changes and see if you have any suggestions for how to improve them?