### PR TITLE
Use case-insensitive match for email and logins

### DIFF
--- a/ghutil/ghutil.go
+++ b/ghutil/ghutil.go
@@ -134,8 +134,9 @@ func (ghc *GitHubClient) VerifyRepoHasClaLabels(ctx context.Context, orgName str
 // in the passed-in configuration for enforcing the CLA.
 func MatchAccount(account config.Account, accounts []config.Account) bool {
 	for _, account2 := range accounts {
-		if account.Name == account2.Name && account.Email == account2.Email &&
-			account.Login == account2.Login {
+		if account.Name == account2.Name &&
+			strings.EqualFold(account.Email, account2.Email) &&
+			strings.EqualFold(account.Login, account2.Login) {
 			return true
 		}
 	}

--- a/ghutil/ghutil_test.go
+++ b/ghutil/ghutil_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/google/code-review-bot/config"
 	"github.com/google/code-review-bot/ghutil"
 	"github.com/google/go-github/v21/github"
 )
@@ -169,6 +170,58 @@ func TestVerifyRepoHasClaLabels_YesAndNoLabels(t *testing.T) {
 
 	if !ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName) {
 		t.Log("Should have returned true")
+		t.Fail()
+	}
+}
+
+func TestMatchAccount_MatchesCase(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	// Credentials as provided by the user.
+	account := config.Account{
+		Name:  "Jane Doe",
+		Email: "jane@example.com",
+		Login: "JaneDoe",
+	}
+
+	// CLA as configured by the project.
+	accounts := []config.Account{
+		{
+			Name:  "Jane Doe",
+			Email: "jane@example.com",
+			Login: "JaneDoe",
+		},
+	}
+
+	if !ghutil.MatchAccount(account, accounts) {
+		t.Log("Should have returned true")
+		t.Fail()
+	}
+}
+
+func TestMatchAccount_DoesNotMatchCase(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	// Credentials as provided by the user.
+	account := config.Account{
+		Name:  "Jane Doe",
+		Email: "Jane@example.com",
+		Login: "janedoe",
+	}
+
+	// CLA as configured by the project.
+	accounts := []config.Account{
+		{
+			Name:  "Jane Doe",
+			Email: "jane@example.com",
+			Login: "JaneDoe",
+		},
+	}
+
+	if ghutil.MatchAccount(account, accounts) {
+		t.Log("Should have returned false")
 		t.Fail()
 	}
 }

--- a/ghutil/ghutil_test.go
+++ b/ghutil/ghutil_test.go
@@ -220,8 +220,8 @@ func TestMatchAccount_DoesNotMatchCase(t *testing.T) {
 		},
 	}
 
-	if ghutil.MatchAccount(account, accounts) {
-		t.Log("Should have returned false")
+	if !ghutil.MatchAccount(account, accounts) {
+		t.Log("Should have returned true")
 		t.Fail()
 	}
 }


### PR DESCRIPTION
This gives us more flexibility around email addresses and GitHub logins, which may be different cases on GitHub vs. the config. We've run into one such instance before, which required us to update the CLA to match the user specification; with this change, it's automatically more flexible by default.

@DiSiqueira – if you don't mind, I'd appreciate you taking a quick look at this. Thanks in advance!