### PR TITLE
Search for a repository configuration in the provided config file

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -52,6 +52,12 @@ func main() {
 		logging.Fatalf("-org must be non-empty or `org` must be specified in cfg file")
 	}
 
+	// Get the repo name from command-line flags or config file.
+	repoName := *repoFlag
+	if repoName == "" {
+		repoName = cfg.Repo
+	}
+
 	prNumbers := make([]uint64, 0)
 	if *prFlag != "" {
 		prElements := strings.Split(*prFlag, ",")
@@ -77,7 +83,7 @@ func main() {
 	ghc := ghutil.NewClient(tc)
 	repoSpec := ghutil.GitHubProcessSpec{
 		Org:        orgName,
-		Repo:       *repoFlag,
+		Repo:       repoName,
 		Pulls:      prNumbers,
 		UpdateRepo: *updateRepoFlag,
 	}


### PR DESCRIPTION
Currently, if the user doesn't provide a repository in the arguments (`--repo`), the code-review-bot will process all the repositories in the organization/user account, even if a repository (`repo`) is present in the configuration file. 

How to reproduce:
```bash
% cat config.json
{
  "auth": "8d10dummyauthtoken2328",
  "org": "DiSiqueira",
  "repo": "code-review-bot"
}
% ./crbot
Repo: DiSiqueira/AllFood
Error getting info on label 'cla: yes' for repo 'DiSiqueira/AllFood': GET https://api.github.com/repos/DiSiqueira/AllFood/labels/cla:%20yes: 404 Not Found []
Label 'cla: yes' does not exist in repo 'DiSiqueira/AllFood'
Error getting info on label 'cla: no' for repo 'DiSiqueira/AllFood': GET https://api.github.com/repos/DiSiqueira/AllFood/labels/cla:%20no: 404 Not Found []
Label 'cla: no' does not exist in repo 'DiSiqueira/AllFood'
Repo: DiSiqueira/ansible-lab
Error getting info on label 'cla: yes' for repo 'DiSiqueira/ansible-lab': GET https://api.github.com/repos/DiSiqueira/ansible-lab/labels/cla:%20yes: 404 Not Found []
Label 'cla: yes' does not exist in repo 'DiSiqueira/ansible-lab'
Error getting info on label 'cla: no' for repo 'DiSiqueira/ansible-lab': GET https://api.github.com/repos/DiSiqueira/ansible-lab/labels/cla:%20no: 404 Not Found []
Label 'cla: no' does not exist in repo 'DiSiqueira/ansible-lab'
...
```

This PR fixes it by looking into the configuration file when the user does not specify the '--repo' argument. This behavior was chosen to keep consistency with how the `--org` argument and the `org` field in the configuration file works. 