### PR TITLE
Split each test into separate make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,19 @@
 LEVEL = .
 include $(LEVEL)/common.mk
 
-gofmt_test:
+go_test:
+	$(VERB) echo
 	$(VERB) echo "Running tests via 'go test' ..."
-	$(VERB) go test ./...
+	$(VERB) go test -v ./...
+
+gofmt_test:
+	$(VERB) echo
 	$(VERB) echo "Running 'go fmt' test ..."
 	$(VERB) ./gofmt_test.sh
 
-test: gofmt_test
+ghutil_test:
+	$(VERB) echo
+	$(VERB) echo "Running tests in 'ghutil' recursively ..."
 	$(VERB) $(MAKE) VERBOSE=$(VERBOSE) -s -C ghutil test
+
+test: go_test gofmt_test ghutil_test


### PR DESCRIPTION
Also added `-v` flag to `go test` to get more verbose output, which can
help with debugging test failures in the future.