### PR TITLE
Added a `go mod tidy` test to ensure module config is clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,8 @@ ghutil_test:
 	$(VERB) echo "Running tests in 'ghutil' recursively ..."
 	$(VERB) $(MAKE) VERBOSE=$(VERBOSE) -s -C ghutil test
 
-test: go_test gofmt_test ghutil_test
+go_mod_tidy_test:
+	$(VERB) echo "Running 'go mod tidy' test ..."
+	$(VERB) ./go_mod_tidy_test.sh
+
+test: go_test gofmt_test ghutil_test go_mod_tidy_test

--- a/ghutil/Makefile
+++ b/ghutil/Makefile
@@ -25,8 +25,9 @@ $(MOCK): $(SRC) $(HEADER)
 	$(VERB) (cat $(HEADER) && mockgen -source $(SRC) -package ghutil) > $(MOCK)
 
 test:
-	$(VERB) echo "mockgen diff test (if no output, then ok)"
+	$(VERB) echo "Running mockgen diff test ..."
 	$(VERB) (cat $(HEADER) && mockgen -source $(SRC) -package ghutil) | diff -u $(MOCK) -
+	$(VERB) echo "PASSED"
 
 clean:
 	$(VERB) rm -f $(MOCK)

--- a/go_mod_tidy_test.sh
+++ b/go_mod_tidy_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -u
+#
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that we have run `go mod tidy` to keep our modules config clean.
+
+declare -r GO_MOD="go.mod"
+declare -r GO_SUM="go.sum"
+
+declare -r GO_MOD_ORIG="go.mod.orig"
+declare -r GO_SUM_ORIG="go.sum.orig"
+
+declare -i success=0
+
+cp "${GO_MOD}" "${GO_MOD_ORIG}"
+cp "${GO_SUM}" "${GO_SUM_ORIG}"
+
+go mod tidy
+
+diff -u "${GO_MOD}" "${GO_MOD_ORIG}" || success=1
+diff -u "${GO_SUM}" "${GO_SUM_ORIG}" || success=1
+
+mv "${GO_MOD_ORIG}" "${GO_MOD}"
+mv "${GO_SUM_ORIG}" "${GO_SUM}"
+
+if [[ ${success} == 0 ]]; then
+  echo PASSED
+else
+  echo FAILED
+fi
+exit ${success}


### PR DESCRIPTION
This test uses `go mod tidy` to ensure that we are running with the
simplest and cleanest `go mod` config that we can, given our current set
of dependencies. `go mod tidy` should be consistent for the same inputs,
so if we're not changing our (pinned) dependencies, this test should not
fail.

However, it should fail (intentionally) if we change any dependencies or
any versions of dependencies and add new dependencies without removing
the old ones.

Also unified test output to make it more consistent.