### PR TITLE
Enable fast-finish and allow failures for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 dist: bionic
+sudo: false
+
 language: go
 go:
   - "1.11.x"
   - "1.12.x"
   - "1.13.x"
-sudo: false
 
 os:
   - linux
@@ -26,6 +27,12 @@ os:
 
 env:
   - GO111MODULE=on
+
+matrix:
+  allow_failures:
+    - os: osx
+
+  fast_finish: true
 
 before_script:
   - go build ./...


### PR DESCRIPTION
* macOS tests sometimes are queued for hours at a time due to there
  being (presumably) fewer instances of macOS test runners, so we might
  as well not wait for them
* enable fast finish for the same reason: if the Linux tests passed,
  consider it passing immediately, and we'll check up on macOS tests later
  to ensure we're not breaking on that platform, but at least it won't
  be in our critical path