### PR TITLE
Only run Travis for pushes to the `master` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ os:
 env:
   - GO111MODULE=on
 
+branches:
+  only:
+    - master
+
 matrix:
   allow_failures:
     - os: osx


### PR DESCRIPTION
Pushes to PRs are automatically handled, so this just avoids
automatically running Travis CI on any other branch, unless it's
explicitly added to this list.