### PR TITLE
Use `stretchr/testify` for cleaner asserts

### DIFF
--- a/ghutil/ghutil_test.go
+++ b/ghutil/ghutil_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/google/code-review-bot/config"
 	"github.com/google/code-review-bot/ghutil"
@@ -83,10 +84,7 @@ func TestGetAllRepos_OrgAndRepo(t *testing.T) {
 	mockGhc.Repositories.EXPECT().Get(ctx, orgName, repoName).Return(&repo, nil, nil)
 
 	repos := ghc.GetAllRepos(ctx, orgName, repoName)
-	if len(repos) != 1 {
-		t.Logf("repos is not of length 1: %v", repos)
-		t.Fail()
-	}
+	assert.Equal(t, 1, len(repos), "repos is not of length 1: %v", repos)
 }
 
 func TestGetAllRepos_OrgOnly(t *testing.T) {
@@ -102,10 +100,7 @@ func TestGetAllRepos_OrgOnly(t *testing.T) {
 	mockGhc.Repositories.EXPECT().List(ctx, orgName, nil).Return(expectedRepos, nil, nil)
 
 	actualRepos := ghc.GetAllRepos(ctx, orgName, "")
-	if len(expectedRepos) != len(actualRepos) {
-		t.Logf("Expected repos: %v, actual repos: %v", expectedRepos, actualRepos)
-		t.Fail()
-	}
+	assert.Equal(t, len(expectedRepos), len(actualRepos), "Expected repos: %v, actual repos: %v", expectedRepos, actualRepos)
 }
 
 func TestVerifyRepoHasClaLabels_NoLabels(t *testing.T) {
@@ -117,10 +112,7 @@ func TestVerifyRepoHasClaLabels_NoLabels(t *testing.T) {
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaYes).Return(noLabel, nil, nil)
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaNo).Return(noLabel, nil, nil)
 
-	if ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName) {
-		t.Log("Should have returned false")
-		t.Fail()
-	}
+	assert.False(t, ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName))
 }
 
 func TestVerifyRepoHasClaLabels_HasYesOnly(t *testing.T) {
@@ -134,10 +126,7 @@ func TestVerifyRepoHasClaLabels_HasYesOnly(t *testing.T) {
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaYes).Return(&label, nil, nil)
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaNo).Return(noLabel, nil, nil)
 
-	if ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName) {
-		t.Log("Should have returned false")
-		t.Fail()
-	}
+	assert.False(t, ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName))
 }
 
 func TestVerifyRepoHasClaLabels_HasNoOnly(t *testing.T) {
@@ -151,10 +140,7 @@ func TestVerifyRepoHasClaLabels_HasNoOnly(t *testing.T) {
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaYes).Return(noLabel, nil, nil)
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaNo).Return(&label, nil, nil)
 
-	if ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName) {
-		t.Log("Should have returned false")
-		t.Fail()
-	}
+	assert.False(t, ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName))
 }
 
 func TestVerifyRepoHasClaLabels_YesAndNoLabels(t *testing.T) {
@@ -168,10 +154,7 @@ func TestVerifyRepoHasClaLabels_YesAndNoLabels(t *testing.T) {
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaYes).Return(&labelYes, nil, nil)
 	mockGhc.Issues.EXPECT().GetLabel(ctx, orgName, repoName, ghutil.LabelClaNo).Return(&labelNo, nil, nil)
 
-	if !ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName) {
-		t.Log("Should have returned true")
-		t.Fail()
-	}
+	assert.True(t, ghc.VerifyRepoHasClaLabels(ctx, orgName, repoName))
 }
 
 func TestMatchAccount_MatchesCase(t *testing.T) {
@@ -194,10 +177,7 @@ func TestMatchAccount_MatchesCase(t *testing.T) {
 		},
 	}
 
-	if !ghutil.MatchAccount(account, accounts) {
-		t.Log("Should have returned true")
-		t.Fail()
-	}
+	assert.True(t, ghutil.MatchAccount(account, accounts))
 }
 
 func TestMatchAccount_DoesNotMatchCase(t *testing.T) {
@@ -220,9 +200,7 @@ func TestMatchAccount_DoesNotMatchCase(t *testing.T) {
 		},
 	}
 
-	if !ghutil.MatchAccount(account, accounts) {
-		t.Log("Should have returned true")
-	}
+	assert.True(t, ghutil.MatchAccount(account, accounts))
 }
 
 func TestDifferentAuthorAndCommitter(t *testing.T) {
@@ -277,10 +255,7 @@ func TestDifferentAuthorAndCommitter(t *testing.T) {
 	}
 
 	commitIsCompliant, commitNonComplianceReason := ghutil.ProcessCommit(&commit, claSigners)
-	if !commitIsCompliant {
-		t.Log("Commit should have been marked compliant; reason: ", commitNonComplianceReason)
-		t.Fail()
-	}
+	assert.True(t, commitIsCompliant, "Commit should have been marked compliant; reason: ", commitNonComplianceReason)
 }
 
 func TestCanonicalizeEmail_Gmail(t *testing.T) {
@@ -296,10 +271,7 @@ func TestCanonicalizeEmail_Gmail(t *testing.T) {
 	}
 
 	for input, expected := range goldenInputOutput {
-		if expected != ghutil.CanonicalizeEmail(input) {
-			t.Log("Should have returned true")
-			t.Fail()
-		}
+		assert.Equal(t, expected, ghutil.CanonicalizeEmail(input))
 	}
 }
 
@@ -333,9 +305,6 @@ func TestGmailAddress_PeriodsDoNotMatchCLA(t *testing.T) {
 			},
 		}
 
-		if !ghutil.MatchAccount(account, accounts) {
-			t.Log("Should have returned true")
-			t.Fail()
-		}
+		assert.True(t, ghutil.MatchAccount(account, accounts))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/google/go-github/v21 v21.0.0
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
@@ -16,6 +18,11 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Traditionally, Go tests require writing `if not X then fail()` when what
we really want to write is `assert X`. This leads to hard-to-read code
since the condition is inverted, and very verbose if statements with
boilerplate code to output a message via `t.Logf()` followed by
`t.Fail()` on a separate line.

This library simplifies asserts to just a single line, makes it natural
to write and easy to read, without losing the (optional) addition of a
human-readable error message.

There's certainly a cost to having an additional dependency (and its
transitive dependencies), but as I was already considering writing a
very similar library to improve the testing in this project, this is
welcome news to not have to do that myself.