### PR TITLE
Add extensive tests for ProcessPullRequest()

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -87,5 +87,5 @@ func main() {
 		Pulls:      prNumbers,
 		UpdateRepo: *updateRepoFlag,
 	}
-	ghc.ProcessOrgRepo(ctx, repoSpec, claSigners)
+	ghc.ProcessOrgRepo(ghc, ctx, repoSpec, claSigners)
 }


### PR DESCRIPTION
Refactored most methods in ghutil.go to pass `*GitHubClient` as the
first argument of every function, and assigned functions to struct
fields which are now function pointers, rather than standard member
methods defined on the struct, allowing us to mock out any individual
method defined on the struct, which wasn't possible previously.

All new tests have been passing, so there were no changes required and
hence, no behavior changes were introduced as a result of this
refactoring, but the APIs for most methods have been changed, of course.