### PR TITLE
Add support for externally-managed CLAs

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -96,10 +96,11 @@ func main() {
 	// Process org and repo(s) specified on the command-line.
 	ghc := ghutil.NewClient(tc)
 	repoSpec := ghutil.GitHubProcessOrgRepoSpec{
-		Org:        orgName,
-		Repo:       repoName,
-		Pulls:      prNumbers,
-		UpdateRepo: *updateRepoFlag,
+		Org:               orgName,
+		Repo:              repoName,
+		Pulls:             prNumbers,
+		UpdateRepo:        *updateRepoFlag,
+		UnknownAsExternal: cfg.UnknownAsExternal,
 	}
 	ghc.ProcessOrgRepo(ghc, repoSpec, claSigners)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,9 @@ type Secrets struct {
 // which it should run, whether for all repos in a single organization, or a
 // single specific repo.
 type Config struct {
-	Org  string `json:"org,omitempty" yaml:"org,omitempty"`
-	Repo string `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Org               string `json:"org,omitempty" yaml:"org,omitempty"`
+	Repo              string `json:"repo,omitempty" yaml:"repo,omitempty"`
+	UnknownAsExternal bool   `json:"unknown_as_external,omitempty" yaml:"unknown_as_external,omitempty"`
 }
 
 // Account represents a single user record, whether human or a bot, with a name,
@@ -54,12 +55,22 @@ type Company struct {
 	People  []Account `json:"people" yaml:"people"`
 }
 
-// ClaSigners provides the overall structure of the CLA config: individual CLA
-// signers, bots, and corporate CLA signers.
-type ClaSigners struct {
+// ExternalClaSigners represents CLA signers managed by an external process,
+// i.e., not covered by this tool. This is useful for handling migrations into
+// or out of the system provided by Code Review Bot.
+type ExternalClaSigners struct {
 	People    []Account `json:"people,omitempty" yaml:"people,omitempty"`
 	Bots      []Account `json:"bots,omitempty" yaml:"bots,omitempty"`
 	Companies []Company `json:"companies,omitempty" yaml:"companies,omitempty"`
+}
+
+// ClaSigners provides the overall structure of the CLA config: individual CLA
+// signers, bots, and corporate CLA signers.
+type ClaSigners struct {
+	People    []Account           `json:"people,omitempty" yaml:"people,omitempty"`
+	Bots      []Account           `json:"bots,omitempty" yaml:"bots,omitempty"`
+	Companies []Company           `json:"companies,omitempty" yaml:"companies,omitempty"`
+	External  *ExternalClaSigners `json:"external,omitempty" yaml:"external,omitempty"`
 }
 
 // parseFile is a helper method for parsing any of the YAML or JSON files we

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,94 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/go-yaml/yaml"
+	"github.com/stretchr/testify/assert"
+)
+
+func parseClaSigners(t *testing.T, claYaml string, claSigners *ClaSigners) {
+	err := yaml.Unmarshal([]byte(claYaml), claSigners)
+	if err != nil {
+		t.Logf("Error parsing YAML: %v", err)
+		t.Fail()
+	}
+}
+
+func TestParseClaSignersEmpty(t *testing.T) {
+	var claSigners ClaSigners
+	parseClaSigners(t, "", &claSigners)
+	assert.Equal(t, 0, len(claSigners.People))
+	assert.Equal(t, 0, len(claSigners.Bots))
+	assert.Equal(t, 0, len(claSigners.Companies))
+	assert.Nil(t, claSigners.External)
+}
+
+func TestParseClaSignersSimple(t *testing.T) {
+	claYaml := `
+people:
+  - name: First Last
+    email: first@example.com
+    github: first-last
+`
+	var claSigners ClaSigners
+	parseClaSigners(t, claYaml, &claSigners)
+	assert.Equal(t, 1, len(claSigners.People), "Should have exactly 1 entry in the `people` section")
+	person := claSigners.People[0]
+	assert.Equal(t, "First Last", person.Name)
+	assert.Equal(t, "first@example.com", person.Email)
+	assert.Equal(t, "first-last", person.Login)
+
+	assert.Equal(t, 0, len(claSigners.Bots))
+	assert.Equal(t, 0, len(claSigners.Companies))
+	assert.Nil(t, claSigners.External)
+}
+
+func TestParseClaSignersWithExternalNamed(t *testing.T) {
+	claYaml := `
+people:
+  - name: First Last
+    email: first@example.com
+    github: first-last
+
+external:
+  people:
+    - name: User Name
+      email: user@name.example
+      github: user-name
+`
+	var claSigners ClaSigners
+	parseClaSigners(t, claYaml, &claSigners)
+	assert.Equal(t, 1, len(claSigners.People), "Should have exactly 1 entry in the `people` section")
+	person := claSigners.People[0]
+	assert.Equal(t, "First Last", person.Name)
+	assert.Equal(t, "first@example.com", person.Email)
+	assert.Equal(t, "first-last", person.Login)
+
+	assert.Equal(t, 0, len(claSigners.Bots))
+	assert.Equal(t, 0, len(claSigners.Companies))
+	assert.NotNil(t, claSigners.External)
+
+	external := claSigners.External
+	assert.Equal(t, 1, len(external.People), "Should have exactly 1 entry in the external `people` section")
+	extPerson := external.People[0]
+	assert.Equal(t, "User Name", extPerson.Name)
+	assert.Equal(t, "user@name.example", extPerson.Email)
+	assert.Equal(t, "user-name", extPerson.Login)
+	assert.Equal(t, 0, len(external.Bots))
+	assert.Equal(t, 0, len(external.Companies))
+}


### PR DESCRIPTION
This addresses the feature request in issue #27 by enabling incremental
migration to this tool (if using something else), or away from this tool
(if switching to something else), without having to wait until everyone
is added to the new system and removed from the old system.

This change adds support for a new CLA signers config field `external`
where you can list contributors in the same way as in the main CLA
signers block (people, bots, and companies which include groups of
people), as well as a special wildcard `all_others` which can be set to
`true` to enable treating any GitHub username not explicitly listed in
any of the CLA signers block to be treated as an externally-managed CLA.

In the presence of a `[cla: external]` label on the repo, if a commit is
found to be matching the external records (or the wildcard), the entire
PR will be marked with that label, under the expectation that an
external tool will be used for the CLA verification, and CRBot will
simply step aside.

This PR closes #27.

@DiSiqueira, as this is a non-trivial change, would you mind taking a look
at this PR whenever you get a chance? Thanks for your help in advance!