### PR TITLE
Remove `context.Context` from Process*() fns

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -71,13 +71,11 @@ func main() {
 		}
 	}
 
-	ctx := context.Background()
-
 	// Configure authentication and connect to GitHub.
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: cfg.Auth},
 	)
-	tc := oauth2.NewClient(ctx, ts)
+	tc := oauth2.NewClient(context.Background(), ts)
 
 	// Process org and repo(s) specified on the command-line.
 	ghc := ghutil.NewClient(tc)
@@ -87,5 +85,5 @@ func main() {
 		Pulls:      prNumbers,
 		UpdateRepo: *updateRepoFlag,
 	}
-	ghc.ProcessOrgRepo(ghc, ctx, repoSpec, claSigners)
+	ghc.ProcessOrgRepo(ghc, repoSpec, claSigners)
 }


### PR DESCRIPTION
We don't need to pass around this object as it's only used when calling
out to the GitHub APIs via the `go-github` package. Although we were
initially considering storing it in the GitHubClient struct, Go docs
(https://golang.org/pkg/context/) suggest otherwise:

> Do not store Contexts inside a struct type; instead, pass a Context
> explicitly to each function that needs it.

Thus, under the assumption that these objects are cheap to construct, we
will just create them whenever they're needed, rather than passing
around the same `context.Context` object throughout the entire program.

Since we've already been using `context.Background()` which is never
cancelled, has no values, and no deadline, there should be no semantic
change to create a few more of such contexts in the program as needed.

Closes #41

@DiSiqueira, what do you think of this change?