### PR TITLE
Output verbose errors for test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ before_script:
   - go generate ./...
 
 script:
-  - make test
+  - make test VERBOSE=1


### PR DESCRIPTION
This will make it easier and faster to understand and debug errors;
without the VERBOSE=1 setting, we get cryptic errors such as:

https://travis-ci.org/google/code-review-bot/jobs/609754900#L437

> ```
> Running 'go fmt' test ...
> failed: ./ghutil/ghutil_test.go
> gofmt files passed: 6 / 7
> Makefile:24: recipe for target 'gofmt_test' failed
> make: *** [gofmt_test] Error 1
> ```

which can only be debugged further by running `make test VERBOSE=1`
locally, which should simply be done automatically by Travis CI.