### PR TITLE
Move package-level comments to package declaration

### DIFF
--- a/ghutil/ghutil.go
+++ b/ghutil/ghutil.go
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(mbrukman): in the future, consider using the recently-added
+// `-copyright_filename` flag: https://github.com/golang/mock/pull/234
+//
+//go:generate mockgen -source ghutil.go -destination mock_ghutil.go -package ghutil -self_package github.com/google/code-review-bot/ghutil
+
 // Package ghutil provides utility methods for determining CLA compliance of
 // pull requests on GitHub repositories, and adding/removing labels and
 // comments.
-
-// TODO(mbrukman): in the future, consider using the recently-added
-// `-copyright_filename` flag: https://github.com/golang/mock/pull/234
-
-//go:generate mockgen -source ghutil.go -destination mock_ghutil.go -package ghutil -self_package github.com/google/code-review-bot/ghutil
 package ghutil
 
 import (


### PR DESCRIPTION
This should fix the one remaining `golint` comment warning:
https://goreportcard.com/report/github.com/google/code-review-bot#golint

This is a follow-up to PR #45 and is part of the fix for issue #44.