### PR TITLE
Combine org, repo, PR, and update into structs

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -95,7 +95,7 @@ func main() {
 
 	// Process org and repo(s) specified on the command-line.
 	ghc := ghutil.NewClient(tc)
-	repoSpec := ghutil.GitHubProcessSpec{
+	repoSpec := ghutil.GitHubProcessOrgRepoSpec{
 		Org:        orgName,
 		Repo:       repoName,
 		Pulls:      prNumbers,


### PR DESCRIPTION
Previously, we were passing around each of these parameters as separate
atoms (which matched the API of the `go-github` library we are using).
However, this is making APIs more complex as we have more and more
parameters, so this change simplifies the API by putting together all
the parameters into a struct.

Note that we actually have two structs as we may want to specify
that we need to process under different conditions:

* specific org, one or all repos, one or many or all PRs
* specific org, single repo, single PR