### PR TITLE
Fix processing `-pr` flag for specific list of PRs

### DIFF
--- a/cmd/crbot/crbot.go
+++ b/cmd/crbot/crbot.go
@@ -74,16 +74,16 @@ func main() {
 		repoName = cfg.Repo
 	}
 
-	prNumbers := make([]uint64, 0)
+	prNumbers := make([]int, 0)
 	if *prFlag != "" {
 		prElements := strings.Split(*prFlag, ",")
-		prNumbers := make([]uint64, len(prElements))
+		prNumbers = make([]int, len(prElements))
 		for idx, elt := range prElements {
-			num, err := strconv.ParseUint(elt, 10, 32)
+			num, err := strconv.ParseInt(elt, 10, 32)
 			if err != nil {
 				logging.Fatalf("Invalid value for flag -pr: %s", *prFlag)
 			}
-			prNumbers[idx] = num
+			prNumbers[idx] = int(num)
 		}
 	}
 


### PR DESCRIPTION
Previously, we were creating a new variable `prNumbers` in each loop
iteration, which was shadowing the variable outside of the loop, and
hence we were always passing in an empty list of PR numbers to the
processing function, which then defaulted to querying all open PRs in
the given repo.

Also fixed other minor issues: typo in the API method (which was
generating mocks of the same name, but which didn't match the actual
struct method, and fixed the type of pull request numbers (`int`, not
`uint64`).

Made the specific list of PR processing match the whole-repo processing
by querying for complete `github.PullRequest` records via the API.

Added tests to validate both processing options: specific list of PR
numbers as well as querying the repo for the full list of open PRs.

Fixes #51.