### PR TITLE
Fix IsExternal() to handle partially-external PRs

### DIFF
--- a/ghutil/ghutil_test.go
+++ b/ghutil/ghutil_test.go
@@ -1010,7 +1010,9 @@ func TestIsExternal_JaneIsUnlisted_UnknownAsExternal(t *testing.T) {
 	}
 
 	commits := []*github.RepositoryCommit{
+		createCommit(john, jane),
 		createCommit(jane, jane),
+		createCommit(jane, john),
 	}
 
 	for _, commit := range commits {


### PR DESCRIPTION
This change fixes the case where one of (author, committer) has signed
the CLA, while the other does not, but the "treat unknown as external"
flag is on, which means `IsExternal()` should return `true` and this
should be handled by the external CLA verification tool.

Previously, `IsExternal()` returned `false` in this case, causing an
error by marking the PR as being non-compliant when it should have been
marked as being handled externally.