### PR TITLE
Remove extra `else` after `if` with a `return`

### DIFF
--- a/ghutil/ghutil.go
+++ b/ghutil/ghutil.go
@@ -522,14 +522,14 @@ func processPullRequest(ghc *GitHubClient, prSpec GitHubProcessSinglePullSpec, c
 
 		// No need to add any other CLA-related labels or comments to this PR.
 		return nil
+	}
+
+	if issueClaLabelStatus.HasExternal {
+		logging.Infof("  PR has [%s] label, but shouldn't", LabelClaExternal)
+		removeLabel(LabelClaExternal)
 	} else {
-		if issueClaLabelStatus.HasExternal {
-			logging.Infof("  PR has [%s] label, but shouldn't", LabelClaExternal)
-			removeLabel(LabelClaExternal)
-		} else {
-			logging.Infof("  PR doesn't have [%s] label, and shouldn't", LabelClaExternal)
-			// Nothing to do here.
-		}
+		logging.Infof("  PR doesn't have [%s] label, and shouldn't", LabelClaExternal)
+		// Nothing to do here.
 	}
 
 	if pullRequestStatus.Compliant {


### PR DESCRIPTION
Suggested via `golint`:

Line 525: warning: if block ends with a return statement, so drop this else and
outdent its block (golint)