### PR TITLE
Build with Go 1.14, drop Go source build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 dist: bionic
-sudo: false
 
 language: go
 go:
   - "1.11.x"
   - "1.12.x"
   - "1.13.x"
-  - "master"
+  - "1.14.x"
 
 os:
   - linux


### PR DESCRIPTION
The prebuilt versions are so much faster (~40-50 sec.) than the source build
(~3.5 min) that it is not worth it, especially since we're not using or relying
on any features that are being added/removed on the Go trunk. This saves us a
bit of time waiting for tests to turn green on PRs prior to merge.

Additional minor fixes:

* s/Google Inc./Google LLC/
* removed deprecated `sudo: false` setting