### PR TITLE
Also run GitHub CI tests on macOS and drop Go 1.16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,13 @@ on:
 
 jobs:
   build:
-    runs-on: 'ubuntu-20.04'
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.16', '1.15', '1.14', '1.13', '1.12' ]
+        # Go 1.16 seems to change `go mod tidy` semantics, so it's not
+        # possible to make it and all other versions pass with the same
+        # contents of `go.mod` file.
+        go: [ '1.15', '1.14', '1.13', '1.12' ]
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Go 1.16 seems to change `go mod tidy` semantics, so it's not possible to make
it and all other versions pass with the same contents of `go.mod` file.