### PR TITLE
Update CI badge to specifically use `main` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Go Report Card][go-report-card-badge]][go-report-card-url]
 [![API docs][godoc-badge]][godoc-url]
 
-[github-ci-badge]: https://github.com/google/code-review-bot/actions/workflows/main.yml/badge.svg
-[github-ci-url]: https://github.com/google/code-review-bot/actions/workflows/main.yml
+[github-ci-badge]: https://github.com/google/code-review-bot/actions/workflows/main.yml/badge.svg?branch=main
+[github-ci-url]: https://github.com/google/code-review-bot/actions/workflows/main.yml?query=branch%3Amain
 [go-report-card-badge]: https://goreportcard.com/badge/github.com/google/code-review-bot
 [go-report-card-url]: https://goreportcard.com/report/github.com/google/code-review-bot
 [godoc-badge]: https://img.shields.io/badge/godoc-reference-5272B4.svg


### PR DESCRIPTION
Previously, it was just pointing to the workflow without the branch restriction, so it would just show the latest status for any PR, which could be failing, but we want to specifically refer to the `main` branch as that is what should be stable, and what external users get when they download and build/install the binary.

Since we're not modifying any code, we can [skip ci].