### PR TITLE
Update to Go 1.16 as minimum requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.16', '1.15', '1.14', '1.13', '1.12' ]
+        go: [ '1.19', '1.18', '1.17', '1.16' ]
         os: [ 'ubuntu-22.04', 'macos-12' ]
     name: Go ${{ matrix.go }} (${{ matrix.os }})
     steps:
@@ -41,9 +41,7 @@ jobs:
         run: go build -v ./...
 
       - name: Install dependencies for testing
-        run: |
-          go get github.com/golang/mock/gomock@v1.6.0
-          go get github.com/golang/mock/mockgen@v1.6.0
+        run: go install github.com/golang/mock/mockgen@v1.6.0
 
       - name: Generate mocks for testing
         run: go generate ./...

--- a/README.md
+++ b/README.md
@@ -11,22 +11,13 @@
 [godoc-badge]: https://img.shields.io/badge/godoc-reference-5272B4.svg
 [godoc-url]: https://godoc.org/github.com/google/code-review-bot
 
-## Prerequisites
-
-Ensure that you have installed Go 1.11 or higher to enable support for [Go
-modules](https://github.com/golang/go/wiki/Modules) via `go mod`.
-
-If you're using Go 1.11 or 1.12, set the environment variable `GO111MODULE=on`
-(Go 1.13 and later versions [automatically enable module
-support](https://blog.golang.org/modules2019)).
-
 ## Building
 
 To build the `crbot` tool without a cloned repo (assuming that `$GOPATH/bin` is
 in your `$PATH`):
 
 ```bash
-$ go get github.com/google/code-review-bot/cmd/crbot
+$ go install github.com/google/code-review-bot/cmd/crbot@latest
 $ crbot [options]
 ```
 
@@ -44,8 +35,7 @@ $ ./crbot [options]
 Install [GoMock](https://github.com/golang/mock):
 
 ```bash
-$ go get github.com/golang/mock/gomock@v1.6.0
-$ go get github.com/golang/mock/mockgen@v1.6.0
+$ go install github.com/golang/mock/mockgen@v1.6.0
 ```
 
 Generate the mocks:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/code-review-bot
 
-go 1.12
+go 1.16
 
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible


### PR DESCRIPTION
* Add newer Go versions (1.19, 1.18, 1.17) to CI config
* Update `go.mod` to list Go 1.16
* Update `go get` commands for mockgen to `go install` instead in GitHub
  Actions config as well as in the README
* We don't need to install `gomock` as it's only a library dependency,
  not a binary, and will be automatically downloaded during the build
* Drop versions 1.15, 1.14, 1.13, and 1.12 from CI config and docs;
  they're quite old at this point, and not supported by the Go team
  anyway
* Drop Go module instructions in the README for Go 1.11 and 1.12